### PR TITLE
Overall improvements to logging

### DIFF
--- a/Classes/Command/ImportRedirectCommand.php
+++ b/Classes/Command/ImportRedirectCommand.php
@@ -121,29 +121,26 @@ class ImportRedirectCommand extends Command implements LoggerAwareInterface
             if (!empty($response['ok'])) {
                 $msg = \sprintf(NotificationHandler::IMPORT_SUCCESS_MESSAGE, \count($response['ok']));
                 $io->success($msg);
-                $this->logger->debug($msg);
-                $this->logger->debug(\print_r($response['ok'], true));
+                $this->logger->debug($msg. PHP_EOL . \implode(PHP_EOL, $response['ok']));
             }
             if (!empty($response['error'])) {
                 $errorMessages = [];
                 foreach ($response['error'] as $messages) {
                     $errorMessages = \array_merge($errorMessages, $messages);
                 }
-                $io->error(NotificationHandler::ERROR_MESSAGE . LF . implode(LF, $errorMessages));
-                $this->logger->error(NotificationHandler::ERROR_MESSAGE);
-                $this->logger->error(\print_r($errorMessages, true));
+                $msg = NotificationHandler::ERROR_MESSAGE . PHP_EOL . \implode(PHP_EOL, $errorMessages);
+                $io->error($msg);
+                $this->logger->error($msg);
             }
             if (!empty($response['skipped'])) {
                 $msg = \sprintf(NotificationHandler::IMPORT_SKIPPED_MESSAGE, \count($response['skipped']));
                 $io->note($msg);
-                $this->logger->warning($msg);
-                $this->logger->warning(\print_r($response['skipped'], true));
+                $this->logger->warning($msg . PHP_EOL . \implode(PHP_EOL, $response['skipped']));
             }
             if (!empty($response['duplicates'])) {
                 $msg = \sprintf(NotificationHandler::IMPORT_DUPLICATES_MESSAGE, \count($response['duplicates']));
                 $io->note($msg);
-                $this->logger->warning($msg);
-                $this->logger->warning(\print_r($response['duplicates'], true));
+                $this->logger->warning($msg . PHP_EOL . \implode(PHP_EOL, $response['duplicates']));
             }
 
             $this->notificationHandler->sendImportResultAsEmail($response);

--- a/Classes/Command/ImportRedirectCommand.php
+++ b/Classes/Command/ImportRedirectCommand.php
@@ -195,8 +195,9 @@ class ImportRedirectCommand extends Command
         return false;
     }
 
-    protected function getConfigurationFromItem(array $item)
+    protected function getConfigurationFromItem(array $item): Configuration
     {
+        /** @var Configuration */
         $configuration = GeneralUtility::makeInstance(Configuration::class);
         if (isset($item['status_code'])) {
             $configuration->setTargetStatusCode((int)$item['status_code']);
@@ -214,7 +215,7 @@ class ImportRedirectCommand extends Command
         if (!is_file($filePath)) {
             throw new \UnexpectedValueException(sprintf('File "%s" does not exist', $filePath), 1568544111);
         }
-        if (!StringUtility::endsWith(strtolower($filePath), '.csv')) {
+        if (!\str_ends_with(strtolower($filePath), '.csv')) {
             throw new \UnexpectedValueException(sprintf('File "%s" is no CSV file', $filePath), 1568544112);
         }
 

--- a/Classes/Command/ImportRedirectCommand.php
+++ b/Classes/Command/ImportRedirectCommand.php
@@ -148,6 +148,15 @@ class ImportRedirectCommand extends Command implements LoggerAwareInterface
             $this->notificationHandler->sendThrowableAsEmail($exception);
             $this->logger->error($exception->getMessage(), $this->notificationHandler->throwableToArray($exception));
             $io->error($exception->getMessage());
+            return 2;
+        }
+
+        if (!empty($response['error'])) {
+            return 2;
+        }
+
+        if (!empty($response['skipped']) || !empty($response['duplicates'])) {
+            return 1;
         }
 
         return 0;

--- a/Classes/Command/ImportRedirectCommand.php
+++ b/Classes/Command/ImportRedirectCommand.php
@@ -86,14 +86,15 @@ class ImportRedirectCommand extends Command
             $io->warning('Dry run enabled!');
         }
 
+        /** @var CsvReader */
         $csvReader = GeneralUtility::makeInstance(CsvReader::class);
         $csvReader->heading = true;
         $csvReader->delimiter = ';';
         $csvReader->enclosure = '';
-        $csvReader->parse($filePath);
 
         try {
             $this->validateFilePath($filePath);
+            $csvReader->parse($filePath);
 
             $data = $csvReader->data;
             if (empty($data)) {

--- a/Classes/Command/ImportRedirectCommand.php
+++ b/Classes/Command/ImportRedirectCommand.php
@@ -15,9 +15,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\HttpUtility;
-use TYPO3\CMS\Core\Utility\StringUtility;
 
 class ImportRedirectCommand extends Command
 {
@@ -31,16 +31,21 @@ class ImportRedirectCommand extends Command
     /** @var NotificationHandler */
     protected $notificationHandler;
 
+    /** @var ExtensionConfiguration */
+    protected $extensionConfiguration;
+
     /** @var array */
     protected $externalDomains = [];
 
     public function __construct(
         string $name = null,
-        NotificationHandler $notificationHandler
+        NotificationHandler $notificationHandler,
+        ExtensionConfiguration $extensionConfiguration
     ) {
         $this->redirectRepository = GeneralUtility::makeInstance(RedirectRepository::class);
         $this->urlMatcher = GeneralUtility::makeInstance(UrlMatcher::class);
         $this->notificationHandler = $notificationHandler;
+        $this->extensionConfiguration = $extensionConfiguration;
 
         parent::__construct($name);
     }
@@ -98,6 +103,10 @@ class ImportRedirectCommand extends Command
 
             $data = $csvReader->data;
             if (empty($data)) {
+                $allowEmptyFile = $this->extensionConfiguration->get('redirect_generator', 'allow_empty_import_file');
+                if ($allowEmptyFile) {
+                    return 0;
+                }
                 throw new \UnexpectedValueException('CSV is empty, nothing can be imported!');
             }
 

--- a/Readme.md
+++ b/Readme.md
@@ -28,6 +28,7 @@ Set the following extension configuration options to enable email notifications:
   * 0 (error): Only receive error messages
   * 1 (warning): Receive error and warning messages
   * 2 (info): Receive all messages
+* *allow_empty_import_file*: If true an empty CSV file will silently skip the import, otherwise an error is thrown
 
 ## Usage
 

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -9,6 +9,9 @@
             <trans-unit id="config.notificationLevel" resname="config.notificationLevel">
                 <source>Level of notifications to send: Send notification of this level or below, can be one of: 0 (error), 1 (warning), 2 (info).</source>
             </trans-unit>
+            <trans-unit id="config.allowEmptyImportFile" resname="config.allowEmptyImportFile">
+                <source>Allow empty import file: If true, am empty CSV file will silenty skip the import. If false, an empty CSV file will trigger an error during import.</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -2,3 +2,5 @@
 notification_email =
 # cat=basic/enable/b; type=options[error=0,warning=1,info=2]; label=LLL:EXT:redirect_generator/Resources/Private/Language/locallang_be.xlf:config.notificationLevel
 notification_level = 0
+# cat=basic/enable/c; type=boolean; label=LLL:EXT:redirect_generator/Resources/Private/Language/locallang_be.xlf:config.allowEmptyImportFile
+allow_empty_import_file = 0


### PR DESCRIPTION
Implements Step 2 in #19 

* Use constants for log messages to unify them
* Also log to TYPO3 log file
* Log precise information about each imported redirect to log file (debug for successful imports, warning for skipped or duplicate imports)
* Some fixes and simplification to error message logging
* Introduced option to allow empty CSV files for import (will silently skip the import if acceptable)
* Some deprecation and other fixes