### PR TITLE
Feature: Split Duplicates in Import in Conflicting and Non Conflicting

### DIFF
--- a/Classes/Command/ImportRedirectCommand.php
+++ b/Classes/Command/ImportRedirectCommand.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 namespace GeorgRinger\RedirectGenerator\Command;
 
 use GeorgRinger\RedirectGenerator\Domain\Model\Dto\Configuration;
-use GeorgRinger\RedirectGenerator\Exception\DuplicateException;
+use GeorgRinger\RedirectGenerator\Exception\ConflictingDuplicateException;
+use GeorgRinger\RedirectGenerator\Exception\NonConflictingDuplicateException;
 use GeorgRinger\RedirectGenerator\Repository\RedirectRepository;
 use GeorgRinger\RedirectGenerator\Service\CsvReader;
 use GeorgRinger\RedirectGenerator\Service\UrlMatcher;
@@ -216,12 +217,10 @@ class ImportRedirectCommand extends Command implements LoggerAwareInterface
                 $this->redirectRepository->addRedirect($item['source'], $targetUrl, $configuration, $dryRun);
 
                 $response['ok'][] = 'Redirect added: ' . $item['source'] . ' => ' . $item['target'];
-            } catch (DuplicateException $e) {
-                $arrayKey = 'non_conflicting';
-                if($e->isTargetDifferent()) {
-                    $arrayKey = 'conflicting';
-                }
-                $response['duplicates'][$arrayKey][] = $e->getMessage();
+            } catch (NonConflictingDuplicateException $e) {
+                $response['duplicates']['non_conflicting'][] = $e->getMessage();
+            } catch (ConflictingDuplicateException $e) {
+                $response['duplicates']['conflicting'][] = $e->getMessage();
             } catch (\Exception $e) {
                 $response['error'][$e->getCode()][] = $e->getMessage();
             }

--- a/Classes/Exception/ConflictingDuplicateException.php
+++ b/Classes/Exception/ConflictingDuplicateException.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace GeorgRinger\RedirectGenerator\Exception;
+
+use GeorgRinger\RedirectGenerator\Exception\DuplicateException;
+
+class ConflictingDuplicateException extends DuplicateException
+{
+}

--- a/Classes/Exception/DuplicateException.php
+++ b/Classes/Exception/DuplicateException.php
@@ -5,27 +5,4 @@ namespace GeorgRinger\RedirectGenerator\Exception;
 
 class DuplicateException extends \Exception
 {
-    protected bool $targetDifferent = false;
-
-    public function __construct(
-        string $message = "",
-        int $code = 0,
-        bool $targetDifferent = false,
-        ?\Throwable $previous = null
-    ) {
-        parent::__construct($message, $code, $previous);
-        $this->targetDifferent = $targetDifferent;
-    }
-
-    public function isTargetDifferent(): bool
-    {
-        return $this->targetDifferent;
-    }
-
-    public function setTargetDifferent(bool $targetDifferent): DuplicateException
-    {
-        $this->targetDifferent = $targetDifferent;
-
-        return $this;
-    }
 }

--- a/Classes/Exception/DuplicateException.php
+++ b/Classes/Exception/DuplicateException.php
@@ -3,7 +3,29 @@ declare(strict_types=1);
 
 namespace GeorgRinger\RedirectGenerator\Exception;
 
-
 class DuplicateException extends \Exception
 {
+    protected bool $targetDifferent = false;
+
+    public function __construct(
+        string $message = "",
+        int $code = 0,
+        bool $targetDifferent = false,
+        ?\Throwable $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+        $this->targetDifferent = $targetDifferent;
+    }
+
+    public function isTargetDifferent(): bool
+    {
+        return $this->targetDifferent;
+    }
+
+    public function setTargetDifferent(bool $targetDifferent): DuplicateException
+    {
+        $this->targetDifferent = $targetDifferent;
+
+        return $this;
+    }
 }

--- a/Classes/Exception/NonConflictingDuplicateException.php
+++ b/Classes/Exception/NonConflictingDuplicateException.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace GeorgRinger\RedirectGenerator\Exception;
+
+use GeorgRinger\RedirectGenerator\Exception\DuplicateException;
+
+class NonConflictingDuplicateException extends DuplicateException
+{
+}

--- a/Classes/Repository/RedirectRepository.php
+++ b/Classes/Repository/RedirectRepository.php
@@ -5,7 +5,8 @@ namespace GeorgRinger\RedirectGenerator\Repository;
 
 use GeorgRinger\RedirectGenerator\Domain\Model\Dto\Configuration;
 use GeorgRinger\RedirectGenerator\Domain\Model\Dto\UrlInfo;
-use GeorgRinger\RedirectGenerator\Exception\DuplicateException;
+use GeorgRinger\RedirectGenerator\Exception\ConflictingDuplicateException;
+use GeorgRinger\RedirectGenerator\Exception\NonConflictingDuplicateException;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -46,14 +47,14 @@ class RedirectRepository
      * @param string $target
      * @param Configuration $configuration
      * @param bool $dryRun
-     * @throws DuplicateException
+     * @throws ConflictingDuplicateException,NonConflictingDuplicateException
      */
     public function addRedirect(string $url, string $target, Configuration $configuration, bool $dryRun = false): void
     {
         $existingRow = $this->getRedirect($url);
         if (is_array($existingRow)) {
             if ($target !== $existingRow['target']) {
-                throw new DuplicateException(
+                throw new ConflictingDuplicateException(
                     \sprintf(
                         'Redirect for "%s" exists already with ID %s! Existing target is "%s", new target would be "%s".',
                         $url,
@@ -61,19 +62,17 @@ class RedirectRepository
                         $existingRow['target'],
                         $target
                     ),
-                    1568487151,
-                    true
+                    1568487151
                 );
             }
 
-            throw new DuplicateException(
+            throw new NonConflictingDuplicateException(
                 \sprintf(
                     'Redirect for "%s" exists already with ID %s, but has the same target as the new redirect.',
                     $url,
                     $existingRow['uid'],
                 ),
-                1568487151,
-                false
+                1568487151
             );
 
         }

--- a/Classes/Utility/NotificationHandler.php
+++ b/Classes/Utility/NotificationHandler.php
@@ -14,7 +14,8 @@ class NotificationHandler
     public const ERROR_MESSAGE = 'The following errors happened:';
     public const IMPORT_SUCCESS_MESSAGE = '%s redirects have been added!';
     public const IMPORT_SKIPPED_MESSAGE = '%s redirects skipped because source is same as target!';
-    public const IMPORT_DUPLICATES_MESSAGE = '%s redirects skipped because of duplicates!';
+    public const IMPORT_DUPLICATES_CONFLICTING_MESSAGE = '%s redirects skipped because of conflicting duplicates!';
+    public const IMPORT_DUPLICATES_NON_CONFLICTING_MESSAGE = '%s redirects skipped because of non conflicting duplicates.';
 
     /** @var ExtensionConfiguration|null */
     protected $extensionConfiguration = null;
@@ -89,8 +90,17 @@ class NotificationHandler
         if (!empty($data['skipped']) && $level >= 1) {
             $lines[] = \sprintf('[Warning] ' .  self::IMPORT_SKIPPED_MESSAGE, \count($data['skipped']));
         }
-        if (!empty($data['duplicates']) && $level >= 1) {
-            $lines[] = \sprintf('[Warning] ' . self::IMPORT_DUPLICATES_MESSAGE, \count($data['duplicates']));
+        if (!empty($data['duplicates']['conflicting']) && $level >= 1) {
+            $lines[] = \sprintf(
+                '[Warning] ' . self::IMPORT_DUPLICATES_CONFLICTING_MESSAGE,
+                \count($data['duplicates']['conflicting'])
+            );
+        }
+        if (!empty($data['duplicates']['non_conflicting']) && $level >= 2) {
+            $lines[] = \sprintf(
+                '[Info] ' . self::IMPORT_DUPLICATES_NON_CONFLICTING_MESSAGE,
+                \count($data['duplicates']['non_conflicting'])
+            );
         }
 
         if(!empty($lines)) {

--- a/Readme.md
+++ b/Readme.md
@@ -62,6 +62,8 @@ source;target;status_code
 
 A sample CSV file can be found at `EXT:redirect_generator/Resources/Private/Examples/ImportBasic.csv`
 
+In addition an additional column `external` can be added to the CSV. It can be 0 (false) or 1 (true). If 1, the target is interpreted as an external URL and not mapped against a TYPO3 page.
+
 The following options are available:
 
 * `--dry-run`: If set, the redirect won't be added


### PR DESCRIPTION
Discovered duplicates during import (already existing redirects) are split into conflicting and non conflicting duplicates:

## Conflicting duplicates

Conflicting duplicates are duplicates that have a different target than the already existing duplicates.\
They are skipped and trigger a warning. The log message contains more information as well.\
They have pretty much the same behaviour as the old duplicates.

## Non conflicting duplicates

Non conflicting duplicates are duplicates that have the same target as the already existing duplicate.\
So "adding" them can be seen as a noop operation.\
They only result is an info message and they don't result in an error code in the import command (a scheduled task would be successful if only non conflicting duplicates are found).

## Motivation

We have an automatic import of redirects every day. Our customer uploads the full set of redirects of his system to be imported. Therefore most redirects already exist but are the same as the ones in the import file.\
These redirects should not trigger a warning e-mail because they are expected and not problematic. I still want to get a warning mail though, if a target is changed in their system. This might be an error on their side or not but needs manual intervention.

## Miscellaneous

* I replaced the deprecated call to `fetch()` on the Result in the Repository
* I added info about the external column to the README (closes #17)