### PR TITLE
[BUGFIX] Add missing return type to commands

### DIFF
--- a/Classes/Command/AddRedirectCommand.php
+++ b/Classes/Command/AddRedirectCommand.php
@@ -16,8 +16,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class AddRedirectCommand extends Command
 {
-
-    public function configure()
+    public function configure(): void
     {
         $this->setDescription('Add redirect to the redirects table')
             ->addArgument('source', InputArgument::REQUIRED, 'Source')
@@ -38,7 +37,7 @@ class AddRedirectCommand extends Command
             ->setHelp('Add a single redirect from the given source url to the target url. Target URL must be a valid page!');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
         $io->title($this->getDescription());

--- a/Classes/Command/ExportRedirectCommand.php
+++ b/Classes/Command/ExportRedirectCommand.php
@@ -30,7 +30,7 @@ class ExportRedirectCommand extends Command
         parent::__construct('redirect:export');
     }
 
-    public function configure()
+    public function configure(): void
     {
         $this->setDescription('Export redirects as csv')
             ->addArgument('target', InputArgument::REQUIRED, 'Target')
@@ -43,7 +43,7 @@ class ExportRedirectCommand extends Command
             ->setHelp('Export all redirects as CSV');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
         $io->title($this->getDescription());

--- a/Classes/Command/ImportRedirectCommand.php
+++ b/Classes/Command/ImportRedirectCommand.php
@@ -45,7 +45,7 @@ class ImportRedirectCommand extends Command implements LoggerAwareInterface
         parent::__construct('redirect:import');
     }
 
-    public function configure()
+    public function configure(): void
     {
         $this->setDescription('Import redirect')
             ->addArgument('file', InputArgument::REQUIRED, 'File to be imported')
@@ -68,7 +68,7 @@ class ImportRedirectCommand extends Command implements LoggerAwareInterface
             ->setHelp('Import a CSV file as redirects');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
         $io->title($this->getDescription());


### PR DESCRIPTION
The missing return type leads to a fatal error due to incompatibility with the symfony Command class.

Fixes: #26 